### PR TITLE
Added ability to write response stats to a CSV file.

### DIFF
--- a/slapper.go
+++ b/slapper.go
@@ -220,7 +220,7 @@ func attack(trgt *targeter, timeout time.Duration, ch <-chan time.Time, stats ch
 		DisableKeepAlives:   false,
 		DisableCompression:  true,
 		MaxIdleConnsPerHost: 100,
-		IdleConnTimeout:     10 * time.Second,
+		IdleConnTimeout:     30 * time.Second,
 		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 	}
 
@@ -260,9 +260,13 @@ func attack(trgt *targeter, timeout time.Duration, ch <-chan time.Time, stats ch
 
 				responsesReceived.Add(1)
 
-				if stats != nil && response != nil {
+				if stats != nil {
+					code := 0
+					if err == nil && response != nil {
+						code = response.StatusCode
+					}
 					select {
-					case stats <- respInfo{code: response.StatusCode, durationMs: int(elapsedMs)}:
+					case stats <- respInfo{code: code, durationMs: int(elapsedMs)}:
 					case <-quit:
 					}
 				}

--- a/slapper.go
+++ b/slapper.go
@@ -220,7 +220,7 @@ func attack(trgt *targeter, timeout time.Duration, ch <-chan time.Time, stats ch
 		DisableKeepAlives:   false,
 		DisableCompression:  true,
 		MaxIdleConnsPerHost: 100,
-		IdleConnTimeout:     30 * time.Second,
+		IdleConnTimeout:     10 * time.Second,
 		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 	}
 
@@ -260,7 +260,7 @@ func attack(trgt *targeter, timeout time.Duration, ch <-chan time.Time, stats ch
 
 				responsesReceived.Add(1)
 
-				if stats != nil {
+				if stats != nil && response != nil {
 					select {
 					case stats <- respInfo{code: response.StatusCode, durationMs: int(elapsedMs)}:
 					case <-quit:


### PR DESCRIPTION
This adds the `-out filename` flag to the slapper command. The response stats will be written to a CSV file if it is provided.

The file will have the format `response code, response time in ms`. E.g.
```
200, 5
200, 10
...
404, 5
```

This file can be post-processed to get response time histograms per code, percentiles, etc.

I have tested the performance of writing to a file. Writing to a file does not impede performance even at `25000 QPS` agains a local lighweight server. The QPS remains approximately the same with and without `-out` option.