### PR TITLE
Add support for passing the Host header

### DIFF
--- a/slapper.go
+++ b/slapper.go
@@ -208,7 +208,6 @@ func (trgt *targeter) nextRequest() (*http.Request, error) {
 
 	for key, headers := range trgt.header {
 		for _, header := range headers {
-			req.Header.Add(key, header)
 			if key == "Host" {
 				req.Host = header;
 			} else {

--- a/slapper.go
+++ b/slapper.go
@@ -209,6 +209,11 @@ func (trgt *targeter) nextRequest() (*http.Request, error) {
 	for key, headers := range trgt.header {
 		for _, header := range headers {
 			req.Header.Add(key, header)
+			if key == "Host" {
+				req.Host = header;
+			} else {
+				req.Header.Add(key, header)
+			}
 		}
 	}
 


### PR DESCRIPTION
As it was mentioned in https://github.com/golang/go/issues/7682 go lang http client does not support setting the Host header the same way as others. This requests adds a necessary workaround for this.

That's quite handy when testing calls through proxies like envoy, because they dispatch against it.